### PR TITLE
Allow register and memory arguments.

### DIFF
--- a/havm.py
+++ b/havm.py
@@ -143,6 +143,21 @@ while position < len(rom):
         continue
     
     if NOEXEC == False and LABEL_IN == False:
+        afnc = rom[position + 1]
+        if str(afnc).startswith("$"):
+            register_index = int(str(afnc)[1:])
+            if 0 <= register_index < len(reg):
+                rom[position + 1] = reg[register_index]
+            else:
+                print(f"Error: Invalid register index '{register_index}' at position {position}.")
+                sys.exit(19)
+        if str(afnc).startswith("#"):
+            register_index = int(str(afnc)[1:])
+            if 0 <= register_index < len(reg):
+                rom[position + 1] = memory[register_index]
+            else:
+                print(f"Error: Invalid register index '{register_index}' at position {position}.")
+                sys.exit(19)
         
         if command == "@INCLUDE":
             try:
@@ -205,7 +220,6 @@ while position < len(rom):
             NOEXEC = True
             reg[1] = rom[position] + rom[position + 1]
         elif command == "RCONCAT":
-            NOEXEC = True
             reg[1] = reg[rom[position]] + reg[rom[position + 1]]
         elif command == "SPUSH":
             NOEXEC = True
@@ -314,10 +328,10 @@ while position < len(rom):
                 position = rom[position] - 1
         
         elif command == "INC":
-            counter = rom[position] - 1
+            counter = rom[position]
             counters[counter] = counters[counter] + 1
         elif command == "DEC":
-            counter = rom[position] - 1
+            counter = rom[position]
             counters[counter] = counters[counter] - 1
         elif command == "GCN":
             reg[13] = counters[rom[position]]


### PR DESCRIPTION
**Created on:** 02/23/2024.
### Feature:
Add register-argument and memory-argument processing.
Use `$00` to `$16` to select a register as argument.
And use `#0000` to `#1023` to select a memory adress as argument.

### Rationale
Enhance usability by allowing $ and # to be used as arguments to commands.
The problem with the current system is the inability to properly send a register value as argument.
While there was `PUSHA` for this, it was cumbersome and inefficient.

### Potential Deprecations and impact
- Deprecate `PUSHA`
- Deprecate command variants that are specifically made for registers or memory, unless absolutely required (like `RCPY` or `MCPY`).